### PR TITLE
scale default instance to bare metal

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,11 +5,10 @@ variable "region" {
 
 variable "instance_type" {
   description = "Type of EC2 instance to provision"
-  default     = "t2.micro"
+  default     = "m7g.metal"
 }
 
 variable "instance_name" {
   description = "EC2 instance name"
   default     = "Provisioned by Terraform"
 }
-


### PR DESCRIPTION
Update the defaul instance type to `m7g.metal` to ensure that SSH users experience no terminal delays.